### PR TITLE
Fixes the genfun link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ multiple arguments. See also: [Clojure
 protocols](http://clojure.org/reference/protocols) but on any number of types
 across all arguments of the individual functions.
 
-`protocols` is built on top of [`genfun`](npm.im/genfun), a fast,
+`protocols` is built on top of [`genfun`](https://npm.im/genfun), a fast,
 prototype-based multimethod library, but this is mostly all behind the scenes.
 
 On top of providing a nice, clear interface for defining interfaces, this


### PR DESCRIPTION
The link to genfun package was redirecting to a 404 page on GitHub because the hostname being read was the repo itself.
